### PR TITLE
Fixed #71 - Improve top header for small screens

### DIFF
--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-18 22:01+0100\n"
+"POT-Creation-Date: 2015-05-04 23:46+0100\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -184,7 +184,6 @@ msgstr "Cumulativo relativo"
 
 #: contracts/templates/contracts/analysis/contracted_lorenz_curve/graph.html:42
 #: contracts/templates/contracts/analysis/contracts_time_series/graph.html:53
-#: contracts/templates/contracts/analysis/health_system/graph.html:53
 #: contracts/templates/contracts/analysis/legislation_application_time_series/graph.html:55
 #: contracts/templates/contracts/analysis/procedure_type_time_series/graph.html:56
 #: contracts/templates/contracts/entity_view/tab_data/graph.html:51
@@ -417,7 +416,6 @@ msgstr ""
 "desde euros até milhões de euros."
 
 #: contracts/templates/contracts/analysis/contracts_time_series/graph.html:32
-#: contracts/templates/contracts/analysis/health_system/graph.html:32
 #: contracts/templates/contracts/analysis/legislation_application_time_series/graph.html:34
 #: contracts/templates/contracts/analysis/procedure_type_time_series/graph.html:35
 #: contracts/templates/contracts/entity_view/tab_data/graph.html:32
@@ -425,14 +423,11 @@ msgid "month"
 msgstr "mês"
 
 #: contracts/templates/contracts/analysis/contracts_time_series/graph.html:40
-#: contracts/templates/contracts/analysis/health_system/graph.html:40
 msgid "Number of signed contracts"
 msgstr "Número de contratos assinados"
 
 #: contracts/templates/contracts/analysis/contracts_time_series/main.html:4
 #: contracts/templates/contracts/analysis/contracts_time_series/main.html:7
-#: contracts/templates/contracts/analysis/health_system/main.html:4
-#: contracts/templates/contracts/analysis/health_system/main.html:7
 msgid "When Portugal contract most?"
 msgstr "Quando é que o estado mais contrata?"
 
@@ -846,7 +841,7 @@ msgstr ""
 #: contracts/templates/contracts/entity_view/tab_data/graph.html:38
 #: contracts/templates/contracts/main_page.html:28
 #: contracts/templates/contracts/main_page.html:47
-#: main/templates/base/top_header.html:17 main/templates/main_page.html:26
+#: main/templates/base/top_header.html:24 main/templates/main_page.html:26
 msgid "Contracts"
 msgstr "Contratos"
 
@@ -1318,7 +1313,7 @@ msgid "categories"
 msgstr "categorias"
 
 #: contracts/views.py:39 contracts/views.py:127 contracts/views.py:192
-#: deputies/views.py:24 law/views.py:29 main/templates/pagination.html:24
+#: deputies/views.py:24 law/views.py:30 main/templates/pagination.html:24
 msgid "page"
 msgstr "página"
 
@@ -1418,7 +1413,7 @@ msgstr "com pelo menos"
 #: deputies/templates/deputies/analysis/deputies_survival_distribution/graph.html:38
 #: deputies/templates/deputies/base/navigation_items.html:3
 #: deputies/templates/deputies/deputies_list.html:3
-#: main/templates/base/top_header.html:24 main/templates/main_page.html:68
+#: main/templates/base/top_header.html:31 main/templates/main_page.html:68
 msgid "Deputies"
 msgstr "Deputados"
 
@@ -2105,15 +2100,15 @@ msgstr "tipos"
 msgid "document"
 msgstr "documento"
 
-#: law/views.py:124
+#: law/views.py:125
 msgid "How many laws are enacted yearly?"
 msgstr "Quantas leis são criadas anualmente?"
 
-#: law/views.py:125
+#: law/views.py:126
 msgid "Impact of EU Law in the Portuguese Law"
 msgstr "Impacto da lei Europeia na lei Portuguesa"
 
-#: law/views.py:126
+#: law/views.py:127
 msgid "Evolution of the portuguese Law"
 msgstr "Evolução da Lei portuguesa"
 
@@ -2290,16 +2285,20 @@ msgstr "Lei (Série I)"
 msgid "Search"
 msgstr "Procurar"
 
-#: main/templates/base/top_header.html:7 main/templates/main_page.html:4
+#: main/templates/base/top_header.html:7
+msgid "Toggle navigation"
+msgstr "Mostrar menu"
+
+#: main/templates/base/top_header.html:13 main/templates/main_page.html:4
 #: main/templates/main_page.html.py:7
 msgid "Publics"
 msgstr "Públicos"
 
-#: main/templates/base/top_header.html:31
+#: main/templates/base/top_header.html:38
 msgid "Law"
 msgstr "Lei"
 
-#: main/templates/base/top_header.html:40
+#: main/templates/base/top_header.html:47
 msgid "Language"
 msgstr "Idioma"
 

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -13,7 +13,7 @@
     {# boostrap #}
     <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/dropdown.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
     {% if REQUIRE_DATEPICKER %}
         {# moment.js to daterangepicker.js #}

--- a/main/templates/base/top_header.html
+++ b/main/templates/base/top_header.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-default navbar-static-top ">
     <div class="container">
         <div class="navbar-header">
             <a class="navbar-brand" href="{% url "home" %}">

--- a/main/templates/base/top_header.html
+++ b/main/templates/base/top_header.html
@@ -3,14 +3,21 @@
 <nav class="navbar navbar-default navbar-static-top ">
     <div class="container">
         <div class="navbar-header">
-            <a class="navbar-brand" href="{% url "home" %}">
-                <img alt="{% trans "Publics" %}"
-                     src="{% static "images/logo_big.png" %}"
+             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">{% trans "Toggle navigation" %}</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+            <a class="navbar-brand" href="{% url 'home' %}">
+                <img alt="{% trans 'Publics' %}"
+                     src="{% static 'images/logo_big.png' %}"
                      class="img-rounded"
-                     width="44px" style="margin-top: -12px; margin-right: -12px;">
+                     width="44px"
+                     style="margin-top: -12px; margin-right: -12px;">
             </a>
         </div>
-        <div class="navbar-collapse collapse">
+        <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
This collapses the menu and search box and creates a button to toggle it.
Also removes the rounded corners on the top header.

I could just add the bootstrap collapse js plugin instead. What do you think?